### PR TITLE
Add workflow to publish codelab updates to demo site.

### DIFF
--- a/.github/workflows/publish-codelab.yml
+++ b/.github/workflows/publish-codelab.yml
@@ -15,6 +15,10 @@ jobs:
       - name: Package codelab into zip
         run: |
           zip -r codelab.zip index.md codelab.json img
+      - name: Upload the codelab
+        run: |
+          python3 publish.py --token=${{ secrets.token }} --codelab_id=${{ secrets.codelab_id }} --filename=./codelab.zip
+
       - name: List files in the repository
         run: |
           ls ${{ github.workspace }}

--- a/.github/workflows/publish-codelab.yml
+++ b/.github/workflows/publish-codelab.yml
@@ -1,0 +1,21 @@
+name: Publish Codelab
+run-name: Publish codelab 🚀
+on: [push]
+jobs:
+  Publish-Codelab:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: Package codelab into zip
+        run: |
+          zip -r codelab.zip index.md codelab.json img
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/publish.py
+++ b/publish.py
@@ -1,0 +1,55 @@
+import argparse, requests
+
+token = "71e296f577e9f263d85eccab467f811faab66a18"
+codelab_id = "ad52def9-9008-4098-b2b7-d72e5cfd12e8"
+domain = "demo.plusplus.app"
+
+
+def get_presigned_post(token, codelab_id):
+    """Get the pre-signed post details."""
+    url = f"https://{domain}/endpoints/codelabs/upload/api/{codelab_id}/pre-sign/"
+    response = requests.post(url, headers={'authorization': token})
+    if response.status_code != 200:
+        print(response)
+        raise SystemExit("Failed to generate pre-signed post. "
+                         "Do you have the API update feature enabled?")
+    return response.json()
+
+def upload_file(token, data, filename):
+    """Upload file with pre-signed post."""
+    upload_data = data['upload_data']
+    response = requests.post(upload_data['url'],
+                             data=upload_data['fields'],
+                             files={'file': open(filename, "rb")})
+
+    if response.status_code != 204:
+        print(response)
+        raise SystemExit("Failed to upload file")
+
+def update_version(token, codelab_id, data):
+    """Update the codelab version by pointing to the uploaded file."""
+
+    url = f"https://{domain}/endpoints/codelabs/upload/api/{codelab_id}/version/"
+    response = requests.post(url,
+                             headers={'authorization': token},
+                             data={'read_url': data['read_url']})
+
+    if response.status_code != 200:
+        print(response)
+        raise SystemExit("Failed to update version")
+
+
+def main(token, codelab_id, filename):
+    data = get_presigned_post(token, codelab_id)
+    upload_file(token, data, filename)
+    update_version(token, codelab_id, data)
+    url = f"https://{domain}/a/codelabs/{codelab_id}/"
+    print(f"Success! See {url}")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Sample client to publish a codelab to PlusPlus.')
+    parser.add_argument("--token", help="Auth token from plusplus")
+    parser.add_argument("--codelab_id", help="Codelab public ID")
+    parser.add_argument("--filename", help="Zip file to upload")
+    args = parser.parse_args()
+    main(args.token, args.codelab_id, args.filename)

--- a/publish.py
+++ b/publish.py
@@ -1,9 +1,6 @@
 import argparse, requests
 
-token = "71e296f577e9f263d85eccab467f811faab66a18"
-codelab_id = "ad52def9-9008-4098-b2b7-d72e5cfd12e8"
 domain = "demo.plusplus.app"
-
 
 def get_presigned_post(token, codelab_id):
     """Get the pre-signed post details."""


### PR DESCRIPTION
Adding a github action and a script to publish a codelab on every commit.

Example run of the action:

![image](https://github.com/plusplusco/example-codelab/assets/157665/3f009777-d4eb-47fc-ac6c-c689eb06ce98)

Result on plusplus demo site:

![image](https://github.com/plusplusco/example-codelab/assets/157665/08e8101d-12fd-46fd-b5b5-9ef5e0a4135b)

Every push to results in a new run of the action

![image](https://github.com/plusplusco/example-codelab/assets/157665/5fb96989-9a20-4a8d-8ef3-cb28500ea0bd)
